### PR TITLE
:fix: hide reate poll functionality from guest users

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,7 +61,7 @@ const App = () => {
           <Route path="/demo" element={<Demo />} />
           <Route path="/vote" element={<VotePollPage />} />
           <Route path="/polls/results" element={<ViewResultsPage />}/>
-          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/dashboard" element={<Dashboard user={user} />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -139,6 +139,8 @@ const Login = ({ setUser }) => {
   };
 
   const handleGuestLogin = () => {
+    // Set a guest user object without username to indicate guest status
+    setUser({ isGuest: true });
     navigate("/dashboard");
   };
 

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -16,11 +16,12 @@ const NavBar = ({ user, onLogout }) => {
 
         {user ? (
           <div className="user-section">
+            {/* Only show "Create a poll" for authenticated users with username (not guests) */}
+            {user.username && (
+              <Link to="/create-poll" className="nav-link">Create a poll</Link>
+            )}
 
-        <Link to="/create-poll" className="nav-link">Create a poll</Link>
-
-
-            <span className="username">Welcome, {user.username}!</span>
+            <span className="username">Welcome, {user.username || 'Guest'}!</span>
             <button onClick={onLogout} className="logout-btn">
               Logout
             </button>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import PollFormModal from "../components/PollFormModal";
 import { useNavigate } from "react-router-dom";
 
-const Dashboard = () => {
+const Dashboard = ({ user }) => {
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -10,7 +10,10 @@ const Dashboard = () => {
     <div>
       <h3>This is the dashboard/new homepage to view all polls</h3>
 
-      <button onClick={() => setIsModalOpen(true)}>Create New Poll</button>
+      {/* Only show Create New Poll button for authenticated users with username (not guests) */}
+      {user && user.username && (
+        <button onClick={() => setIsModalOpen(true)}>Create New Poll</button>
+      )}
 
       <div className="poll-list">
         <ul>
@@ -18,7 +21,10 @@ const Dashboard = () => {
         </ul>
       </div>
 
-      <PollFormModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
+      {/* Only render PollFormModal for authenticated users */}
+      {user && user.username && (
+        <PollFormModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
- Conditionally show 'Create a poll' button only for authenticated users
- Update NavBar to distinguish between guest and authenticated users
- Modify Dashboard to hide poll creation for guests
- Show Welcome, `username of the login user` message