### PR TITLE
fix: resolve poll loading 500 errors in dashboard for polls/ UI improvement to seperate poll voting form components

### DIFF
--- a/src/components/PollCard.jsx
+++ b/src/components/PollCard.jsx
@@ -36,14 +36,19 @@ const PollCard = ({ poll, isOpen, onToggleMenu, currentUser }) => {
         }
 
         // Check if user owns the poll and it's published - go to host view
-        if (poll.status === "published" && poll.ownerId === currentUser?.id) {
+        // Note: Check both ownerId and userId in case backend uses different property name
+        const isOwner = (poll.ownerId === currentUser?.id) || (poll.userId === currentUser?.id);
+        if (poll.status === "published" && isOwner) {
             navigate(`/polls/host/${poll.id}`);
-        } else if (poll.slug) {
-            // Use slug if available
-            navigate(`/polls/view/${poll.slug}`);
         } else {
-            // Fall back to ID
-            navigate(`/polls/view/${poll.id}`);
+            // For voting, always use slug route - backend expects /api/polls/slug/:slug
+            if (poll.slug) {
+                navigate(`/polls/view/${poll.slug}`);
+            } else {
+                console.error("Poll missing slug for public voting:", poll);
+                alert("This poll cannot be accessed - missing slug");
+                return;
+            }
         }
         };
 

--- a/src/pages/HostPollView.css
+++ b/src/pages/HostPollView.css
@@ -1,0 +1,52 @@
+.host-poll-view {
+  padding: 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.host-poll-container {
+  display: flex;
+  gap: 2rem;
+}
+
+.vote-section {
+  flex: 1;
+}
+
+.overview-section {
+  flex: 1;
+}
+
+.poll-stats {
+  margin: 1rem 0;
+}
+
+.stat-item {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.deadline-display {
+  display: flex;
+  gap: 1rem;
+}
+
+.deadline-buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 768px) {
+  .host-poll-container {
+    flex-direction: column;
+  }
+}

--- a/src/pages/HostPollView.jsx
+++ b/src/pages/HostPollView.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import VoteForm from "../components/VoteForm";
+import "./HostPollView.css";
 
 const HostPollView = () => {
   const { id } = useParams();
@@ -64,38 +65,67 @@ const HostPollView = () => {
 
   return (
     <div className="host-poll-view">
-      <h2>{poll.title}</h2>
-      <p>{poll.description || "No description provided."}</p>
+      <div className="host-poll-container">
+        <div className="vote-section">
+          <h3>Vote on Your Poll</h3>
+          <VoteForm poll={poll} readOnly={false} />
+        </div>
 
-      <div className="deadline-section">
-        <label>Poll ends:</label>
-        {editingDeadline ? (
-          <>
-            <input
-              type="datetime-local"
-              value={newDeadline}
-              onChange={(e) => setNewDeadline(e.target.value)}
-            />
-            <button onClick={handleSaveDeadline}>Save</button>
-            <button onClick={() => setEditingDeadline(false)}>Cancel</button>
-          </>
-        ) : (
-          <>
-            <span>{poll.deadline ? new Date(poll.deadline).toLocaleString() : "No deadline"}</span>
-            <button onClick={() => setEditingDeadline(true)}>Edit</button>
-          </>
-        )}
+        <div className="overview-section">
+          <div className="poll-header">
+            <h2>{poll.title}</h2>
+            <h4>Description:</h4>
+            <p>{poll.description || "No description provided."}</p>
+          </div>
+
+          <div className="poll-stats">
+            <div className="stat-item">
+              <span className="stat-label">Status:</span>
+              <span className="stat-value">{poll.status}</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-label">Participants:</span>
+              <span className="stat-value">{poll.participants || 0}</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-label">Created:</span>
+              <span className="stat-value">{new Date(poll.createdAt).toLocaleDateString()}</span>
+            </div>
+          </div>
+
+          <div className="deadline-section">
+            <h4>Poll Deadline</h4>
+            {editingDeadline ? (
+              <div className="deadline-edit">
+                <input
+                  type="datetime-local"
+                  value={newDeadline}
+                  onChange={(e) => setNewDeadline(e.target.value)}
+                />
+                <div className="deadline-buttons">
+                  <button onClick={handleSaveDeadline}>Save</button>
+                  <button onClick={() => setEditingDeadline(false)}>Cancel</button>
+                </div>
+              </div>
+            ) : (
+              <div className="deadline-display">
+                <span>{poll.deadline ? new Date(poll.deadline).toLocaleString() : "No deadline"}</span>
+                <button onClick={() => setEditingDeadline(true)}>Edit</button>
+              </div>
+            )}
+          </div>
+
+          <div className="actions">
+            <h4>Poll Actions</h4>
+            <div className="action-buttons">
+              <button onClick={handleCopyLink}>Copy Share Link</button>
+              {copySuccess && <span className="copy-feedback">{copySuccess}</span>}
+              <button onClick={() => alert("End Poll logic here")}>End Poll</button>
+              <button onClick={() => alert("Results logic here")}>View Results</button>
+            </div>
+          </div>
+        </div>
       </div>
-
-      <div className="actions">
-        <button onClick={handleCopyLink}>Copy Link</button>
-        {copySuccess && <span className="copy-feedback">{copySuccess}</span>}
-        <button onClick={() => alert("End Poll logic here")}>End Poll</button>
-        <button onClick={() => alert("Results logic here")}>Results</button>
-      </div>
-
-      <h3>Vote Preview</h3>
-      <VoteForm poll={poll} readOnly={false} />
     </div>
   );
 };

--- a/src/pages/VotePollPage.jsx
+++ b/src/pages/VotePollPage.jsx
@@ -16,7 +16,7 @@ const VotePollPage = () => {
         if (slug) {
           url = `http://localhost:8080/api/polls/slug/${slug}`;
         } else if (id) {
-          url = `http://localhost:8080/api/polls/${id}`;
+          url = `http://localhost:8080/api/polls/${id}`;  // Backend expects /api/polls/:pollId
         } else {
           setError("No poll ID or slug provided");
           setLoading(false);
@@ -32,7 +32,6 @@ const VotePollPage = () => {
         }
 
         const pollData = await response.json();
-        console.log("Fetched poll data:", pollData);
         setPoll(pollData);
       } catch (err) {
         console.error("Error fetching poll:", err);


### PR DESCRIPTION
- Issue: Clicking polls from dashboard resulted in 500 Internal Server Error
- Root cause: Frontend was using /api/polls/:id for all poll access, but backend expects:
  * /api/polls/:pollId for owner/host view 
  * /api/polls/slug/:slug for public voting
- Updated navigation logic to use slug-based routes for voting
- Also fixed property name mismatch (ownerId vs userId) for owner detection
- Removed all debugging code mess that i made 🥶
- Create split layout with vote form on left and poll overview on right
- Host can now vote on their own polls directly from host view
- Add poll statistics (status, participants, creation date)
- Include deadline management with edit functionality
- Add poll action buttons (copy link, end poll, view results)