### PR TITLE
Bug/draft flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,10 +13,12 @@ import VotePollPage from "./pages/VotePollPage";
 import ViewResultsPage from "./pages/ViewResultsPage";
 import Dashboard from "./pages/Dashboard"
 import HostPollView from "./pages/HostPollView";
+import PollFormModal from "./components/PollFormModal";
 
 
 const App = () => {
   const [user, setUser] = useState(null);
+  const [isCreatePollOpen, setIsCreatePollOpen] = useState(false);
 
   const cleanupExpiredGuestSession = () => {
     const savedGuestSession = localStorage.getItem('guestSession');
@@ -100,9 +102,16 @@ const App = () => {
     }
   };
 
+  const handleOpenCreatePoll = () => {
+    setIsCreatePollOpen(true);
+  };
+  const handleCloseCreatePoll = () => {
+    setIsCreatePollOpen(false);
+  };
+
   return (
     <div>
-      <NavBar user={user} onLogout={handleLogout} />
+      <NavBar user={user} onLogout={handleLogout} onOpenCreatePoll={handleOpenCreatePoll} />
       <div className="app">
         <Routes>
           <Route path="/login" element={<Login setUser={setUser} />} />
@@ -117,6 +126,9 @@ const App = () => {
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>
+      {isCreatePollOpen && (
+        <PollFormModal isOpen={isCreatePollOpen} onClose={handleCloseCreatePoll} />
+      )}
     </div>
   );
 };

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import "./NavBarStyles.css";
 
-const NavBar = ({ user, onLogout }) => {
+const NavBar = ({ user, onLogout, onOpenCreatePoll }) => {
   return (
     <nav className="navbar">
       <div className="nav-brand">
@@ -11,14 +11,11 @@ const NavBar = ({ user, onLogout }) => {
       </div>
 
       <div className="nav-links">
-
-        
-
         {user ? (
           <div className="user-section">
             {/* Only show "Create a poll" for authenticated users with username (not guests) */}
             {user.username && (
-              <Link to="/create-poll" className="nav-link">Create a poll</Link>
+              <button className="nav-link" onClick={onOpenCreatePoll}>Create a poll</button>
             )}
 
             <span className="username">Welcome, {user.username || 'Guest'}!</span>

--- a/src/components/PollCard.jsx
+++ b/src/components/PollCard.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 
-const PollCard = ({ poll, isOpen, onToggleMenu, currentUser }) => {
+const PollCard = ({ poll, isOpen, onToggleMenu, currentUser, onEditDraft }) => {
   const navigate = useNavigate();
 
   const timeLeft = (deadline) => {
@@ -35,9 +35,16 @@ const PollCard = ({ poll, isOpen, onToggleMenu, currentUser }) => {
             return;
         }
 
-        // Check if user owns the poll and it's published - go to host view
-        // Note: Check both ownerId and userId in case backend uses different property name
+        // Check if user owns the poll
         const isOwner = (poll.ownerId === currentUser?.id) || (poll.userId === currentUser?.id);
+        
+        // If it's a draft and user owns it, open edit modal
+        if (poll.status === "draft" && isOwner) {
+            onEditDraft(poll);
+            return;
+        }
+        
+        // If published and user owns it, go to host view
         if (poll.status === "published" && isOwner) {
             navigate(`/polls/host/${poll.id}`);
         } else {

--- a/src/components/PollFormModal.jsx
+++ b/src/components/PollFormModal.jsx
@@ -117,8 +117,8 @@ const PollFormModal = ({ isOpen, onClose, onPollCreated, initialData }) => {
     try {
       let res;
       if (initialData) {
-        // update existing draft - use put endpoint
-        res = await axios.put(`http://localhost:8080/api/polls/${initialData.id}`,
+        // update existing draft 
+        res = await axios.patch(`http://localhost:8080/api/polls/${initialData.id}`,
           payload, { 
           withCredentials: true});
       } else {
@@ -168,8 +168,8 @@ const PollFormModal = ({ isOpen, onClose, onPollCreated, initialData }) => {
     try {
       let res;
       if (initialData) {
-        // update existing draft
-        res = await axios.put(`http://localhost:8080/api/polls/${initialData.id}`,
+        // update existing draft 
+        res = await axios.patch(`http://localhost:8080/api/polls/${initialData.id}`,
           payload,
           { withCredentials: true }
         );

--- a/src/components/PollFormModal.jsx
+++ b/src/components/PollFormModal.jsx
@@ -117,12 +117,12 @@ const PollFormModal = ({ isOpen, onClose, onPollCreated, initialData }) => {
     try {
       let res;
       if (initialData) {
-        // Update existing draft
+        // update existing draft - use put endpoint
         res = await axios.put(`http://localhost:8080/api/polls/${initialData.id}`,
           payload, { 
           withCredentials: true});
       } else {
-        // Create new poll
+        // create new poll
         res = await axios.post("http://localhost:8080/api/polls",
           payload, { 
           withCredentials: true});
@@ -130,20 +130,21 @@ const PollFormModal = ({ isOpen, onClose, onPollCreated, initialData }) => {
 
       const data = res.data;
 
-      if (!res.status) {
-        setSubmitError(data.error || "Poll creation failed.");
+      if (res.status < 200 || res.status >= 300) {
+        setSubmitError(data.error || "poll creation/update failed.");
       } else {
-        console.log("✅ Poll created:", JSON.stringify(data, null, 2));
-        console.log("Poll options:", data.poll.PollOptions);
-        console.log("Number of options:", data.poll.PollOptions?.length);
+        console.log("poll created/updated:", JSON.stringify(data, null, 2));
         onClose();
         resetForm(); // clear form
-        if (onPollCreated) onPollCreated(); // Refresh dashboard
-        navigate(`/polls/host/${data.poll.id}`);
+        if (onPollCreated) onPollCreated(); // refresh dashboard
+        
+        // navigate to host view - use initialData.id for updates, data.poll?.id for new polls
+        const pollId = initialData ? initialData.id : (data.poll?.id || data.id);
+        navigate(`/polls/host/${pollId}`);
       }
     } catch (err) {
-      console.error("Error:", err);
-      setSubmitError("Network error. Try again.");
+      console.error("error:", err);
+      setSubmitError("network error. try again.");
     } finally {
       setIsLoading(false);
     }
@@ -167,13 +168,13 @@ const PollFormModal = ({ isOpen, onClose, onPollCreated, initialData }) => {
     try {
       let res;
       if (initialData) {
-        // Update existing draft
+        // update existing draft
         res = await axios.put(`http://localhost:8080/api/polls/${initialData.id}`,
           payload,
           { withCredentials: true }
         );
       } else {
-        // Create new poll
+        // create new poll
         res = await axios.post("http://localhost:8080/api/polls",
           payload,
           { withCredentials: true }

--- a/src/components/PollFormModal.jsx
+++ b/src/components/PollFormModal.jsx
@@ -3,7 +3,7 @@ import "./PollFormModal.css";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 
-const PollFormModal = ({ isOpen, onClose }) => {
+const PollFormModal = ({ isOpen, onClose, onPollCreated }) => {
   if (!isOpen) return null;
 
   // =============================
@@ -115,6 +115,7 @@ const PollFormModal = ({ isOpen, onClose }) => {
         console.log("Number of options:", data.poll.PollOptions?.length);
         onClose();
         resetForm(); // clear form
+        if (onPollCreated) onPollCreated(); // Refresh dashboard
         navigate(`/polls/host/${data.poll.id}`);
       }
     } catch (err) {
@@ -150,6 +151,7 @@ const PollFormModal = ({ isOpen, onClose }) => {
       console.log(`✅ Poll ${payload.status === "draft" ? "saved as draft" : "published"}:`, res.data);
       resetForm();
       onClose();
+      if (onPollCreated) onPollCreated(); // Refresh dashboard
       navigate("/dashboard");
     } catch (err) {
       console.error(`Error during ${payload.status} save:`, err);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -9,6 +9,7 @@ const Dashboard = ({ user: currentUser }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingDraft, setEditingDraft] = useState(null);
   const [polls, setPolls] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -38,6 +39,16 @@ const Dashboard = ({ user: currentUser }) => {
   useEffect(() => {
     fetchPolls();
   }, [location.pathname]); // Re-fetch when navigating to dashboard
+
+  const handleEditDraft = (draftPoll) => {
+    setEditingDraft(draftPoll);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setEditingDraft(null);
+  };
 
   const filteredAndSortedPolls = [...polls]
     .filter((poll) => {
@@ -103,13 +114,15 @@ const Dashboard = ({ user: currentUser }) => {
             isOpen={openMenuId === poll.id}
             onToggleMenu={(id) => setOpenMenuId(openMenuId === id ? null : id)}
             currentUser={currentUser}
+            onEditDraft={handleEditDraft}
           />
         ))}
       </ul>
       <PollFormModal 
         isOpen={isModalOpen} 
-        onClose={() => setIsModalOpen(false)} 
+        onClose={handleCloseModal} 
         onPollCreated={fetchPolls}
+        initialData={editingDraft}
       />
     </div>
   );


### PR DESCRIPTION
### 1. Dashboard Auto-Refresh Problem
- Dashboard poll list was not updating after submitting drafts or creating polls
- Users had to manually refresh the page to see their newly created/saved polls
### 2. Draft Editing Workflow Missing
- Clicking on draft polls from dashboard didn't allow users to resume editing
- Users couldn't continue working on partially completed polls
- Draft functionality was incomplete - users could save drafts but not edit them

### Auto-Refresh Implementation
- Added `useLocation` hook to Dashboard to detect navigation changes
- Implemented `useEffect` with `location.pathname` dependency for automatic poll fetching
- Added `onPollCreated` callback system between Dashboard and PollFormModal
- Dashboard now automatically refreshes poll list after any poll creation/saving

### Draft Editing Functionality  
- Added `onEditDraft` callback to PollCard to detect draft poll clicks
- Implemented draft state management in Dashboard with `editingDraft` state
- Added `initialData` prop to PollFormModal for pre-filling form fields
- Used `useEffect` in PollFormModal to populate existing draft data
- Implemented PUT requests for updating drafts vs POST for creating new polls
- Added dynamic modal title ("Edit Draft" vs "Create a Poll")

** added PUT route for backend
- Fix HTTP response validation 
- Implement PUT /api/polls/:id for updating existing drafts vs POST for new polls
- Fix navigation logic to handle both draft updates and new poll creation scenarios
- Enable end-to-end draft editing workflow from dashboard to published poll
- Fixed create a poll button on nav bar