### PR TITLE
Build Smart Poll View Routing at /poll/:slug (Host vs Public)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import VotePollPage from "./pages/VotePollPage";
 import ViewResultsPage from "./pages/ViewResultsPage";
 import Dashboard from "./pages/Dashboard"
 import HostPollView from "./pages/HostPollView";
+import SmartPollView from "./pages/SmartPollView";
 
 
 const App = () => {
@@ -114,6 +115,7 @@ const App = () => {
           <Route path="/polls/host/:id" element={<HostPollView />} />
           <Route path="/polls/view/:id" element={<VotePollPage />} />
           <Route path="/polls/view/:slug" element={<VotePollPage />} />
+          <Route path="/poll/:slug" element={<SmartPollView user={user} />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/src/pages/SmartPollView.jsx
+++ b/src/pages/SmartPollView.jsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import axios from "axios";
+import { API_URL } from "../shared";
+
+const SmartPollView = ({ user }) => {
+  const { slug } = useParams();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const loadAndRedirect = async () => {
+      try {
+        // Fetch poll details
+        const res = await axios.get(`${API_URL}/api/polls/slug/${slug}`, {
+          withCredentials: true,
+        });
+
+        const poll = res.data;
+
+        // Log poll access
+        await axios.post(`${API_URL}/api/polls/${slug}/track`, {}, {
+          withCredentials: true,
+        });
+
+        // Redirect based on ownership
+        const isOwner = user && (user.id === poll.ownerId || user.id === poll.creatorId);
+        if (isOwner) {
+          navigate(`/polls/host/${poll.id}`);
+        } else {
+          navigate(`/polls/view/${slug}`);
+        }
+
+      } catch (err) {
+        console.error("Smart routing failed:", err);
+        if (err.response?.status === 404) {
+          setError("Poll not found.");
+        } else {
+          setError("Failed to load poll.");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadAndRedirect();
+  }, [slug, user, navigate]);
+
+  if (loading) return <div style={{ padding: "2rem", textAlign: "center" }}>Loading poll...</div>;
+  if (error) {
+    return (
+      <div style={{ padding: "2rem", color: "red", textAlign: "center" }}>
+        <h2>Error</h2>
+        <p>{error}</p>
+        <button onClick={() => navigate("/dashboard")}>Back to Dashboard</button>
+      </div>
+    );
+  }
+
+  return null; // Never rendered, because we redirect once loaded
+};
+
+export default SmartPollView;


### PR DESCRIPTION
### Summary of Changes

- ➕ **Added `SmartPollView` page** to handle conditional routing
- 🧭 **Registered route `/poll/:slug`** in `App.jsx`
- 📥 **Fetches poll via `GET /api/polls/slug/:slug`** on mount
- 🧠 **Checks if current user is the poll creator**
  - If **owner**, redirects to `/polls/host/:id`
  - If **not the owner** or unauthenticated, redirects to `/polls/view/:slug`
- 📊 **Logs dashboard access via `POST /api/polls/:slug/track`**
- ⚠️ **Handles error states**: loading, not found (404), and generic fetch errors

### Checklist

- [x] Add route `/poll/:slug` to `App.jsx`
- [x] On mount, fetch poll data from `GET /api/polls/:slug`
- [x] Compare current user ID to `poll.creatorId`
- [x] Redirect to `/polls/host/:id` if user is the creator
- [x] Redirect to `/polls/view/:slug` if user is not the creator or not logged in
- [x] Send `POST /api/polls/:slug/track` to log poll access
- [x] Handle loading, 404, and expired/error poll states

TLDR
- Added new SmartPollView component to handle conditional routing
- On mount, fetches poll by slug and logs access via POST /polls/:slug/track
- Redirects to /polls/host/:id if current user is the poll owner
- Otherwise redirects to /polls/view/:slug for public voting
- Handles loading, not found, and error states
- Route registered in App.jsx as /poll/:slug

Closes #48 